### PR TITLE
BUG:max_tokens 修复

### DIFF
--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -179,7 +179,7 @@ import {
 } from 'src/utils/betas.js'
 import { CLAUDE_IN_CHROME_MCP_SERVER_NAME } from 'src/utils/claudeInChrome/common.js'
 import { CHROME_TOOL_SEARCH_INSTRUCTIONS } from 'src/utils/claudeInChrome/prompt.js'
-import { getMaxThinkingTokensForModel } from 'src/utils/context.js'
+import { CAPPED_DEFAULT_MAX_TOKENS, getMaxThinkingTokensForModel } from 'src/utils/context.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import { logForDiagnosticsNoPII } from 'src/utils/diagLogs.js'
 import { type EffortValue, modelSupportsEffort } from 'src/utils/effort.js'
@@ -858,7 +858,7 @@ export async function* executeNonStreamingRequest(
 
       const adjustedParams = adjustParamsForNonStreaming(
         retryParams,
-        MAX_NON_STREAMING_TOKENS,
+        clientOptions.model,
       )
 
       try {
@@ -1827,6 +1827,11 @@ async function* queryModel(
         }
         const compatProvider = customApiConfig.provider ?? 'anthropic'
         const openAICompatMode = customApiConfig.openaiCompatMode ?? 'chat_completions'
+
+        // OpenAI-compatible APIs (DeepSeek, etc.) have max_tokens limits (typically 8192).
+        // Cap max_tokens to prevent "max_tokens value out of range" errors.
+        const maxTokensForCompat = Math.min(params.max_tokens ?? CAPPED_DEFAULT_MAX_TOKENS, 8192)
+
         if (compatProvider === 'gemini') {
           const geminiRequest = convertAnthropicRequestToGemini({
             model: params.model,
@@ -1835,7 +1840,7 @@ async function* queryModel(
             tools: params.tools,
             tool_choice: params.tool_choice,
             temperature: params.temperature,
-            max_tokens: params.max_tokens,
+            max_tokens: maxTokensForCompat,
             thinking: params.thinking,
             effort,
           })
@@ -1881,7 +1886,7 @@ async function* queryModel(
               tools: params.tools,
               tool_choice: params.tool_choice,
               temperature: params.temperature,
-              max_tokens: params.max_tokens,
+              max_tokens: maxTokensForCompat,
               thinking: params.thinking,
               effort,
             })
@@ -1909,7 +1914,7 @@ async function* queryModel(
             tools: params.tools,
             tool_choice: params.tool_choice,
             temperature: params.temperature,
-            max_tokens: params.max_tokens,
+            max_tokens: maxTokensForCompat,
             thinking: params.thinking,
           })
           if (!openAIRequest.messages || openAIRequest.messages.length === 0) {
@@ -3479,12 +3484,17 @@ export async function queryWithModel({
 // bypass it by setting a client-level timeout, so we can cap higher.
 export const MAX_NON_STREAMING_TOKENS = 64_000
 
+function isMaxTokensCapEnabled(): boolean {
+  // 3P default: false (not validated on Bedrock/Vertex)
+  return getFeatureValue_CACHED_MAY_BE_STALE('tengu_otk_slot_v1', false)
+}
+
 /**
  * Adjusts thinking budget when max_tokens is capped for non-streaming fallback.
  * Ensures the API constraint: max_tokens > thinking.budget_tokens
  *
  * @param params - The parameters that will be sent to the API
- * @param maxTokensCap - The maximum allowed tokens (MAX_NON_STREAMING_TOKENS)
+ * @param model - The model name to determine max tokens cap
  * @returns Adjusted parameters with thinking budget capped if needed
  */
 export function adjustParamsForNonStreaming<
@@ -3492,8 +3502,9 @@ export function adjustParamsForNonStreaming<
     max_tokens: number
     thinking?: BetaMessageStreamParams['thinking']
   },
->(params: T, maxTokensCap: number): T {
-  const cappedMaxTokens = Math.min(params.max_tokens, maxTokensCap)
+>(params: T, model: string): T {
+  const cap = getModelMaxOutputTokens(model).default
+  const cappedMaxTokens = Math.min(params.max_tokens, cap)
 
   // Adjust thinking budget if it would exceed capped max_tokens
   // to maintain the constraint: max_tokens > thinking.budget_tokens
@@ -3515,11 +3526,6 @@ export function adjustParamsForNonStreaming<
     ...adjustedParams,
     max_tokens: cappedMaxTokens,
   }
-}
-
-function isMaxTokensCapEnabled(): boolean {
-  // 3P default: false (not validated on Bedrock/Vertex)
-  return getFeatureValue_CACHED_MAY_BE_STALE('tengu_otk_slot_v1', false)
 }
 
 export function getMaxOutputTokensForModel(model: string): number {


### PR DESCRIPTION
动态拉取模型max_token;
现在非流式 fallback 的 max_tokens cap 改为自适应模型默认值：

Opus 4.6 → 64k（非固定 64k）
Sonnet 4.6 → 32k
Opus 4.5 → 32k
Sonnet 4 → 32k
Haiku 4 → 32k
3.5 Sonnet → 8k
修改内容：

adjustParamsForNonStreaming() 参数从固定的 MAX_NON_STREAMING_TOKENS(64k) 改为 model 字符串
函数内部通过 getModelMaxOutputTokens(model).default 获取模型自适应上限
调用处从 MAX_NON_STREAMING_TOKENS 改为 clientOptions.model